### PR TITLE
use class instead interface

### DIFF
--- a/printInterface.ts
+++ b/printInterface.ts
@@ -1,11 +1,11 @@
 export function generateInterface(iName: string, fields: {[K:string]: {dataTypeName: string, nullable: boolean}}) {
   return `
 
-export interface ${iName} {
+export class ${iName} {
 ${
   Object.entries(fields)
-  .map(([key, typename])=>`  ${key}${typename.nullable?'?':''}: ${typename.dataTypeName}`)
-  .join(",\n")
+  .map(([key, typename])=>`  ${key}${typename.nullable?'?':'!'}: ${typename.dataTypeName}`)
+  .join(";\n\n")
 }
 }`
 }


### PR DESCRIPTION
Would be better to use class instead interface.

This de facto standard already used in most popular typescript projects like: type-graphql, typeorm, class-validator, mikro-orm e t. c.

This better, because can be used in runtime and compile time at the same time.
But interface can be used only in compile time.